### PR TITLE
fix image for Heroku deployment badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/nteract/commuter.svg?branch=master)](https://travis-ci.org/nteract/commuter) [![Heroku](https://heroku-badge.herokuapp.com/?app=nteract-commuter)]
+[![Build Status](https://travis-ci.org/nteract/commuter.svg?branch=master)](https://travis-ci.org/nteract/commuter) [![Heroku](https://heroku-badge.herokuapp.com/?app=nteract-commuter)](https://nteract-commuter.herokuapp.com/)
 
 # com·mut·er
 


### PR DESCRIPTION
Noticed it was loading a bit funny on the README, had it point to the running demo.