### PR TITLE
Wire up NotebookPreview for static display

### DIFF
--- a/packages/commuter-client/package.json
+++ b/packages/commuter-client/package.json
@@ -26,9 +26,10 @@
     "react-scripts": "0.8.5"
   },
   "dependencies": {
-    "aphrodite": "^1.1.0",
     "@nteract/commuter-breadcrumb": "^0.1.0",
     "@nteract/commuter-directory-listing": "^0.1.0",
+    "aphrodite": "^1.1.0",
+    "notebook-preview": "^0.2.3",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-router": "^3.0.2",

--- a/packages/commuter-client/src/Preview.js
+++ b/packages/commuter-client/src/Preview.js
@@ -1,0 +1,34 @@
+import React from "react";
+import { Container } from "semantic-ui-react";
+import NotebookPreview from "notebook-preview";
+
+import 'notebook-preview/styles/theme-light.css';
+
+export default class Preview extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = { notebook: null };
+  }
+
+  componentDidMount() {
+    this.loadData(this.props.params);
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.loadData(nextProps.params);
+  }
+
+  loadData = ({ splat }) => fetch(`/api/contents/${splat}`)
+    .then(res => res.json())
+    .then(notebook => this.setState({ notebook }));
+
+  render() {
+    return (
+      <Container>
+        {this.state.notebook
+          ? <NotebookPreview notebook={this.state.notebook} />
+          : <div> Loading ... </div>}
+      </Container>
+    );
+  }
+}

--- a/packages/commuter-client/src/index.js
+++ b/packages/commuter-client/src/index.js
@@ -3,9 +3,11 @@ import ReactDOM from "react-dom";
 import { Router, Route, browserHistory } from "react-router";
 
 import App from "./App";
+import Preview from "./Preview";
 
 ReactDOM.render(
   <Router history={browserHistory}>
+    <Route path="/notebooks/*" component={Preview} />
     <Route path="/*" component={App} />
   </Router>,
   document.getElementById("root")

--- a/packages/commuter-directory-listing/package.json
+++ b/packages/commuter-directory-listing/package.json
@@ -22,6 +22,7 @@
   "author": "nteract contributors",
   "license": "BSD-3-Clause",
   "dependencies": {
+    "aphrodite": "^1.1.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-router": "^3.0.1",

--- a/packages/commuter-directory-listing/src/components/Table.js
+++ b/packages/commuter-directory-listing/src/components/Table.js
@@ -16,7 +16,7 @@ const ContentTable = props => (
             return (
               <Table.Row key={index}>
                 <Table.Cell>
-                  <Link to={row.path}>
+                  <Link to={`/notebooks/${row.path}`}>
                     <Icon name="book" color="grey" />{row.name}
                   </Link>
                 </Table.Cell>


### PR DESCRIPTION
- [NotebookPreview](https://github.com/nteract/notebook-preview) has styles for generic elements like [\<td\>](https://github.com/nteract/notebook-preview/blob/master/styles/main.css#L45) which is messing up with sematicUI styles. So skip import of `main.css` from NotebookPreview for time being. 