### PR TITLE
Render notebook styles

### DIFF
--- a/packages/commuter-client/package.json
+++ b/packages/commuter-client/package.json
@@ -30,7 +30,7 @@
     "@nteract/commuter-directory-listing": "^0.1.0",
     "aphrodite": "^1.1.0",
     "normalize.css": "^5.0.0",
-    "notebook-preview": "^0.2.3",
+    "notebook-preview": "^0.2.4",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-router": "^3.0.2",

--- a/packages/commuter-client/package.json
+++ b/packages/commuter-client/package.json
@@ -29,6 +29,7 @@
     "@nteract/commuter-breadcrumb": "^0.1.0",
     "@nteract/commuter-directory-listing": "^0.1.0",
     "aphrodite": "^1.1.0",
+    "normalize.css": "^5.0.0",
     "notebook-preview": "^0.2.3",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",

--- a/packages/commuter-client/src/Preview.js
+++ b/packages/commuter-client/src/Preview.js
@@ -2,6 +2,9 @@ import React from "react";
 import { Container } from "semantic-ui-react";
 import NotebookPreview from "notebook-preview";
 
+import 'normalize.css/normalize.css';
+import 'codemirror/lib/codemirror.css';
+import 'notebook-preview/styles/main.css';
 import "notebook-preview/styles/theme-light.css";
 
 export default class Preview extends React.Component {


### PR DESCRIPTION
This renders the styling for notebooks:

![screen shot 2017-02-10 at 3 16 38 pm](https://cloud.githubusercontent.com/assets/836375/22847747/f9eceb48-efa3-11e6-8174-166bb7ff0481.png)

However, we need to change the CSS for nteract to scope to outputs, etc. properly, otherwise it messes up the dashboard view:

![screen shot 2017-02-10 at 3 16 47 pm](https://cloud.githubusercontent.com/assets/836375/22847748/00dc9e3a-efa4-11e6-8abe-3479733974fb.png)

This is not intended to be merged, using this to help me cement what I'm going to do next for notebook preview CSS.

Things to do (externally to this repository):

* [ ] Create `@nteract/notebook-preview` within nteract/nteract
* [ ] Create `@nteract/notebook-preview-demo` within nteract/nteract (likely as a `create-react-app`
* [ ] Scope our global CSS for the notebook app (in nteract/nteract)

---------------------------

Using incognito mode in honor of dark top, light bottoms day on GitHub.