### PR TITLE
bring isDir into s3 services package

### DIFF
--- a/packages/commuter-server/src/routes/contents.js
+++ b/packages/commuter-server/src/routes/contents.js
@@ -1,6 +1,7 @@
 const express = require("express"),
   router = express.Router(),
-  { listObjects, getObject, isDir } = require("./../services/s3");
+  { isDir } = require("./util"),
+  { listObjects, getObject } = require("./../services/s3");
 
 const errObject = (err, path) => ({
   message: `${err.message}: ${path}`,


### PR DESCRIPTION
Follow on to #70.

Looking at the `services/s3` module here, the interface on the s3 service operations should likely have the first argument be the `S3` object (and if necessary, the user could `bind` it).