### PR TITLE
Delete extraneous space

### DIFF
--- a/packages/commuter-client/src/Discovery.js
+++ b/packages/commuter-client/src/Discovery.js
@@ -55,7 +55,7 @@ const DiscoveryItem = props => (
       <Item.Meta>
         <span>Last modified <TimeAgo date={props.last_modified} /></span>
         {props.metadata.authors
-          ? <span> by <Authors authors={props.metadata.authors} /></span>
+          ? <span>by <Authors authors={props.metadata.authors} /></span>
           : null}
       </Item.Meta>
       <Item.Description>


### PR DESCRIPTION
Otherwise there's two spaces between "1 month ago" and "by kylek"