### PR TITLE
proxy /files/ from s3, like jupyter server

### DIFF
--- a/packages/commuter-server/package.json
+++ b/packages/commuter-server/package.json
@@ -39,6 +39,7 @@
     "morgan": "^1.7.0",
     "nbschema": "^0.1.0",
     "node-fetch": "^1.6.3",
+    "s3-proxy": "^1.1.0",
     "winston": "^2.3.0"
   },
   "devDependencies": {

--- a/packages/commuter-server/src/routes/files.js
+++ b/packages/commuter-server/src/routes/files.js
@@ -1,0 +1,14 @@
+const express = require("express"),
+  config = require('../config'),
+  router = express.Router(),
+  s3Proxy = require('s3-proxy');
+
+router.get("/*", s3Proxy({
+  bucket: config.s3.params.Bucket,
+  /* prefix: s3pathPrefix */
+  accessKeyId: config.s3.accessKeyId,
+  secretAccessKey: config.s3.secretAccessKey,
+  overrideCacheControl: 'max-age=100000'
+}))
+
+module.exports = router;

--- a/packages/commuter-server/src/routes/index.js
+++ b/packages/commuter-server/src/routes/index.js
@@ -8,6 +8,7 @@ router.use("/api/ping", (req, res) => {
 
 router.use("/api/contents", require("./contents"));
 router.use("/api/v1/discovery", require("./discovery"));
+router.use("/files", require('./files'));
 
 //commuter-client
 router.get("*", (req, res) => {


### PR DESCRIPTION
In order to fully do #88, #43 we need an endpoint that serves files directly as is. This endpoint is not intended for users to visit directly (same as jupyter), yet is how we'll load images on relative paths.