### PR TITLE
fix(contents): return non-notebook as string for contents API

### DIFF
--- a/packages/commuter-server/src/services/s3.js
+++ b/packages/commuter-server/src/services/s3.js
@@ -78,8 +78,8 @@ const getObject = (path, callback) => {
       // All other files end up as pure strings in the content field
       const file = Object.assign({}, fileObject(s3Response), {
         content: isNotebook(s3Response)
-          ? JSON.parse(s3Response.Body)
-          : s3Response.Body
+          ? JSON.parse(s3Response.Body) // JSON for notebook
+          : s3Response.Body.toString(), // Pure string for everything else
       });
 
       callback(null, file);


### PR DESCRIPTION
Bringing in some fixes from #88 since that's not ready until I finish adapting the express + create-react-app setup. I'll be opening another PR for the `/view/` route.