### PR TITLE
☯️ create a /view/ route as the yin to /files/ yang

### DIFF
--- a/packages/commuter-server/src/routes/view.js
+++ b/packages/commuter-server/src/routes/view.js
@@ -1,0 +1,21 @@
+const express = require("express");
+const { isDir } = require('./util');
+
+const  Log = require("log"),
+  log = new Log("info");
+
+const router = express.Router();
+
+router.get("*", (req, res) => {
+  const path = req.path;
+  log.info('on the view path');
+  if (path.endsWith(".ipynb") || path.endsWith(".html") || path.endsWith("/")) {
+    res.sendFile(path.resolve(__dirname, "..", "..", "build", "index.html"));
+  } else {
+    // TODO: Include the config.basePath
+    const newPath = path.replace(/^\/view\//, '/files/');
+    res.redirect(newPath);
+  }
+});
+
+module.exports = router;


### PR DESCRIPTION
Setting up a `/view/` route. When a user visits `/view/some/test.rmd.html` that includes a relative asset like this:

```html
<img src="plot.png" />
```

It will

* Attempt to load `/view/some/plot.png`
* Get redirected to `/files/some/plot.png`

Result is rendered appropriately, even though we're iframing the HTML.

This matches the mechanics of the jupyter notebook server (though that uses `/notebooks/` and `/view/`).