### PR TITLE
Handle /view/ paths

### DIFF
--- a/packages/commuter-client/package.json
+++ b/packages/commuter-client/package.json
@@ -34,7 +34,7 @@
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
     "react-redux": "^5.0.2",
-    "react-router": "^3.0.2",
+    "react-router-dom": "^4.0.0",
     "react-timeago": "^3.2.0",
     "redux": "^3.6.0",
     "redux-thunk": "^2.2.0",

--- a/packages/commuter-client/src/Commuter.js
+++ b/packages/commuter-client/src/Commuter.js
@@ -24,6 +24,8 @@ class Commuter extends React.Component {
       this.loadData(nextProps);
   }
 
+  handleClick = path => this.props.history.push(path);
+
   loadData = ({ location, dispatch }) =>
     dispatch(fetchContents(stripView(location.pathname)));
 
@@ -34,6 +36,7 @@ class Commuter extends React.Component {
         <BreadCrumb path={pathname} onClick={this.handleClick} />
         <Container className={css(styles.innerContainer)} textAlign="center">
           <DirectoryListing
+            onClick={this.handleClick}
             path={this.props.location.pathname}
             contents={this.props.contents}
             basepath={"/view"}

--- a/packages/commuter-client/src/Commuter.js
+++ b/packages/commuter-client/src/Commuter.js
@@ -27,8 +27,6 @@ class Commuter extends React.Component {
   loadData = ({ location, dispatch }) =>
     dispatch(fetchContents(stripView(location.pathname)));
 
-  handleClick = path => this.props.location.push(path);
-
   render() {
     const pathname = stripView(this.props.location.pathname);
     return (
@@ -36,9 +34,9 @@ class Commuter extends React.Component {
         <BreadCrumb path={pathname} onClick={this.handleClick} />
         <Container className={css(styles.innerContainer)} textAlign="center">
           <DirectoryListing
-            path={pathname}
+            path={this.props.location.pathname}
             contents={this.props.contents}
-            onClick={this.handleClick}
+            basepath={"/view"}
           />
         </Container>
       </Container>

--- a/packages/commuter-client/src/Commuter.js
+++ b/packages/commuter-client/src/Commuter.js
@@ -11,6 +11,8 @@ import { fetchContents } from "./actions";
 
 import { styles } from "./stylesheets/commuter";
 
+import stripView from "./strip-view";
+
 class Commuter extends React.Component {
   static contextTypes = { router: T.object.isRequired };
   componentDidMount() {
@@ -23,12 +25,12 @@ class Commuter extends React.Component {
   }
 
   loadData = ({ location, dispatch }) =>
-    dispatch(fetchContents(location.pathname));
+    dispatch(fetchContents(stripView(location.pathname)));
 
-  handleClick = path => this.context.router.push(path);
+  handleClick = path => this.props.location.push(path);
 
   render() {
-    const { pathname } = this.props.location;
+    const pathname = stripView(this.props.location.pathname);
     return (
       <Container className={css(styles.outerContainer)}>
         <BreadCrumb path={pathname} onClick={this.handleClick} />

--- a/packages/commuter-client/src/Notebook.js
+++ b/packages/commuter-client/src/Notebook.js
@@ -16,6 +16,8 @@ import { css } from "aphrodite";
 
 import { styles } from "./stylesheets/commuter";
 
+import stripView from "./strip-view";
+
 class Notebook extends React.Component {
   componentDidMount() {
     this.loadData(this.props);
@@ -27,7 +29,7 @@ class Notebook extends React.Component {
   }
 
   loadData = ({ location, dispatch }) =>
-    dispatch(fetchNotebook(location.pathname));
+    dispatch(fetchNotebook(stripView(location.pathname)));
 
   render() {
     return (

--- a/packages/commuter-client/src/index.js
+++ b/packages/commuter-client/src/index.js
@@ -2,7 +2,12 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 
-import { Router, Route, browserHistory, IndexRoute } from "react-router";
+import {
+  BrowserRouter as Router,
+  Route,
+  Redirect,
+  Switch
+} from "react-router-dom";
 
 import INITIAL_STATE from "./store/preloadedState";
 import configureStore from "./store/configureStore";
@@ -16,13 +21,17 @@ const store = configureStore(INITIAL_STATE);
 
 ReactDOM.render(
   <Provider store={store}>
-    <Router history={browserHistory}>
-      <Route path="/" component={App}>
-        <IndexRoute component={Commuter} />
-        <Route path="/discover" component={Discovery} />
-        <Route path="*.ipynb" component={Notebook} />
-        <Route path="*" component={Commuter} />
-      </Route>
+    <Router basename="/">
+      <div>
+        <Route exact path="/" render={() => <Redirect to="/view/" />} />
+        <App>
+          <Switch>
+            <Route path="/discover" component={Discovery} />
+            <Route path="/view/*.ipynb" component={Notebook} />
+            <Route path="/view/*" component={Commuter} />
+          </Switch>
+        </App>
+      </div>
     </Router>
   </Provider>,
   document.getElementById("root")

--- a/packages/commuter-client/src/strip-view.js
+++ b/packages/commuter-client/src/strip-view.js
@@ -1,0 +1,1 @@
+export default p => p.replace(/^\/view\//, "/");

--- a/packages/commuter-directory-listing/package.json
+++ b/packages/commuter-directory-listing/package.json
@@ -25,6 +25,7 @@
     "aphrodite": "^1.1.0",
     "react": "^15.4.2",
     "react-dom": "^15.4.2",
+    "react-router-dom": "^4.0.0",
     "semantic-ui-react": "^0.63.6"
   },
   "devDependencies": {

--- a/packages/commuter-directory-listing/src/DirectoryListing.js
+++ b/packages/commuter-directory-listing/src/DirectoryListing.js
@@ -4,6 +4,13 @@ import { Table, Grid, Segment, Icon } from "semantic-ui-react";
 import { Link } from "react-router-dom";
 
 const DirectoryListing = props => {
+  const handleClick = path =>
+    e => {
+      if (props.onClick) {
+        e.preventDefault();
+        props.onClick(path);
+      }
+    };
   const base = props.basepath;
   return (
     <Grid>
@@ -17,14 +24,16 @@ const DirectoryListing = props => {
             </Table.Header>
             <Table.Body>
               {props.contents.map((row, index) => {
+                const fullPath = `${base}${row.path}`;
+
                 switch (row.type) {
                   case "notebook":
                     return (
                       <Table.Row key={index}>
                         <Table.Cell>
-                          <Link to={`${base}${row.path}`}>
+                          <a href={fullPath} onClick={handleClick(fullPath)}>
                             <Icon name="book" color="grey" />{row.name}
-                          </Link>
+                          </a>
                         </Table.Cell>
                         <Table.Cell collapsing textAlign="right" />
                       </Table.Row>
@@ -33,9 +42,9 @@ const DirectoryListing = props => {
                     return (
                       <Table.Row key={index}>
                         <Table.Cell collapsing>
-                          <Link to={`${base}${row.path}`}>
+                          <a href={fullPath} onClick={handleClick(fullPath)}>
                             <Icon name="folder" color="blue" />{row.name}
-                          </Link>
+                          </a>
                         </Table.Cell>
                         <Table.Cell collapsing textAlign="right" />
                       </Table.Row>
@@ -44,9 +53,9 @@ const DirectoryListing = props => {
                     return (
                       <Table.Row key={index}>
                         <Table.Cell collapsing>
-                          <Link to={`${base}${row.path}`}>
+                          <a href={fullPath} onClick={handleClick(fullPath)}>
                             <Icon name="file" color="grey" />{row.name}
-                          </Link>
+                          </a>
                         </Table.Cell>
                         <Table.Cell collapsing textAlign="right" />
                       </Table.Row>

--- a/packages/commuter-directory-listing/src/DirectoryListing.js
+++ b/packages/commuter-directory-listing/src/DirectoryListing.js
@@ -1,6 +1,8 @@
 import React, { PropTypes as T } from "react";
 import { Table, Grid, Segment, Icon } from "semantic-ui-react";
 
+import { Link } from "react-router-dom";
+
 const DirectoryListing = props => {
   const base = props.basepath;
   return (
@@ -20,9 +22,9 @@ const DirectoryListing = props => {
                     return (
                       <Table.Row key={index}>
                         <Table.Cell>
-                          <a href={`${base}${row.path}`}>
+                          <Link to={`${base}${row.path}`}>
                             <Icon name="book" color="grey" />{row.name}
-                          </a>
+                          </Link>
                         </Table.Cell>
                         <Table.Cell collapsing textAlign="right" />
                       </Table.Row>
@@ -31,9 +33,9 @@ const DirectoryListing = props => {
                     return (
                       <Table.Row key={index}>
                         <Table.Cell collapsing>
-                          <a href={`${base}${row.path}`}>
+                          <Link to={`${base}${row.path}`}>
                             <Icon name="folder" color="blue" />{row.name}
-                          </a>
+                          </Link>
                         </Table.Cell>
                         <Table.Cell collapsing textAlign="right" />
                       </Table.Row>
@@ -42,9 +44,9 @@ const DirectoryListing = props => {
                     return (
                       <Table.Row key={index}>
                         <Table.Cell collapsing>
-                          <a href={`${base}${row.path}`}>
+                          <Link to={`${base}${row.path}`}>
                             <Icon name="file" color="grey" />{row.name}
-                          </a>
+                          </Link>
                         </Table.Cell>
                         <Table.Cell collapsing textAlign="right" />
                       </Table.Row>

--- a/packages/commuter-directory-listing/src/DirectoryListing.js
+++ b/packages/commuter-directory-listing/src/DirectoryListing.js
@@ -2,13 +2,7 @@ import React, { PropTypes as T } from "react";
 import { Table, Grid, Segment, Icon } from "semantic-ui-react";
 
 const DirectoryListing = props => {
-  const handleClick = path => e => {
-    if (props.onClick) {
-      e.preventDefault();
-      props.onClick(path);
-    }
-  };
-
+  const base = props.basepath;
   return (
     <Grid>
       <Grid.Column>
@@ -26,10 +20,7 @@ const DirectoryListing = props => {
                     return (
                       <Table.Row key={index}>
                         <Table.Cell>
-                          <a
-                            href={`${row.path}`}
-                            onClick={handleClick(`${row.path}`)}
-                          >
+                          <a href={`${base}${row.path}`}>
                             <Icon name="book" color="grey" />{row.name}
                           </a>
                         </Table.Cell>
@@ -40,10 +31,7 @@ const DirectoryListing = props => {
                     return (
                       <Table.Row key={index}>
                         <Table.Cell collapsing>
-                          <a
-                            href={`${row.path}`}
-                            onClick={handleClick(`${row.path}`)}
-                          >
+                          <a href={`${base}${row.path}`}>
                             <Icon name="folder" color="blue" />{row.name}
                           </a>
                         </Table.Cell>
@@ -54,7 +42,7 @@ const DirectoryListing = props => {
                     return (
                       <Table.Row key={index}>
                         <Table.Cell collapsing>
-                          <a href={row.path} onClick={handleClick(row.path)}>
+                          <a href={`${base}${row.path}`}>
                             <Icon name="file" color="grey" />{row.name}
                           </a>
                         </Table.Cell>
@@ -77,8 +65,7 @@ DirectoryListing.propTypes = {
   contents: T.arrayOf(
     T.shape({ type: T.string, path: T.string, name: T.string })
   ),
-  handleClick: T.func,
-  onClick: T.func
+  basepath: T.string
 };
 
 export default DirectoryListing;


### PR DESCRIPTION
Switching over to React Router v4, handling the `/view/` routes. A worthy refactor after this is to make a top level `Contents` component rather than having separate handling amongst `Commuter` and `Notebook`. There's a lot of action repetition when there shouldn't be. Same thing for the path cleansing.