### PR TITLE
Use base path for urls on the client side

### DIFF
--- a/packages/commuter-client/src/index.js
+++ b/packages/commuter-client/src/index.js
@@ -2,7 +2,8 @@ import React from "react";
 import ReactDOM from "react-dom";
 import { Provider } from "react-redux";
 
-import { Router, Route, browserHistory, IndexRoute } from "react-router";
+import { createHistory, useBasename } from 'history'
+import { Router, Route, IndexRoute } from "react-router";
 
 import INITIAL_STATE from "./store/preloadedState";
 import configureStore from "./store/configureStore";
@@ -12,11 +13,15 @@ import Notebook from "./Notebook";
 import Commuter from "./Commuter";
 import Discovery from "./Discovery";
 
+const history = useBasename(createHistory)({
+  basename: '/view'
+})
+
 const store = configureStore(INITIAL_STATE);
 
 ReactDOM.render(
   <Provider store={store}>
-    <Router history={browserHistory}>
+    <Router history={history}>
       <Route path="/" component={App}>
         <IndexRoute component={Commuter} />
         <Route path="/discover" component={Discovery} />


### PR DESCRIPTION
- Use base path as per documented [here](https://github.com/ReactTraining/react-router/blob/d4aa590dd13848a857ca27508149552458c7cdfb/examples/pinterest/app.js#L7)
- ^^ option is preferred to [this](https://github.com/ReactTraining/react-router/issues/820) 