### PR TITLE
pin codemirror to 5.24.x

### DIFF
--- a/packages/commuter-client/package.json
+++ b/packages/commuter-client/package.json
@@ -26,6 +26,7 @@
     "react-scripts": "^0.9.5"
   },
   "dependencies": {
+    "codemirror": "~5.24.0",
     "@nteract/commuter-breadcrumb": "^0.1.2",
     "@nteract/commuter-directory-listing": "^0.1.2",
     "@nteract/notebook-preview": "^1.0.7",


### PR DESCRIPTION
This has been fixed in nteract/nteract, however there is an incident on npm preventing us from receiving the update. For now, let's go ahead and pin codemirror so that commuter master is fixed.