### PR TITLE
keep content types accurate by configuring router

### DIFF
--- a/packages/commuter-server/src/routes/api/contents.js
+++ b/packages/commuter-server/src/routes/api/contents.js
@@ -1,13 +1,13 @@
 const express = require("express"),
   router = express.Router(),
-  { isDir } = require("./util"),
+  { isDir } = require("../util"),
   {
     listObjects,
     getObject,
     deleteObject,
     deleteObjects,
     uploadObject
-  } = require("./../services/s3");
+  } = require("./../../services/s3");
 
 const errObject = (err, path) => ({
   message: `${err.message}: ${path}`,

--- a/packages/commuter-server/src/routes/api/index.js
+++ b/packages/commuter-server/src/routes/api/index.js
@@ -1,0 +1,23 @@
+const express = require("express"),
+  path = require("path"),
+  bodyParser = require("body-parser"),
+  router = express.Router();
+
+function defaultContentTypeMiddleware(req, res, next) {
+  req.headers["content-type"] = req.headers["content-type"] ||
+    "application/json";
+  next();
+}
+
+router.use(defaultContentTypeMiddleware);
+router.use(bodyParser.json({ limit: "50mb" })); //50mb is the current threshold
+router.use(bodyParser.urlencoded({ extended: true }));
+
+router.use("/ping", (req, res) => {
+  res.json({ message: "pong" });
+});
+
+router.use("/contents", require("./contents"));
+router.use("/v1/discovery", require("./v1/discovery"));
+
+module.exports = router;

--- a/packages/commuter-server/src/routes/api/v1/discovery.js
+++ b/packages/commuter-server/src/routes/api/v1/discovery.js
@@ -1,6 +1,6 @@
 const express = require("express"),
   router = express.Router(),
-  { list } = require("./../services/elasticSearch");
+  { list } = require("./../../../services/elasticSearch");
 
 router.get("/*", (req, res) => {
   const successCb = data => res.json(data);

--- a/packages/commuter-server/src/routes/index.js
+++ b/packages/commuter-server/src/routes/index.js
@@ -2,12 +2,8 @@ const express = require("express"),
   path = require("path"),
   router = express.Router();
 
-router.use("/api/ping", (req, res) => {
-  res.json({ message: "pong" });
-});
+router.use("/api", require("./api"));
 
-router.use("/api/contents", require("./contents"));
-router.use("/api/v1/discovery", require("./discovery"));
 router.use("/files", require("./files"));
 router.use("/view", require("./view"));
 

--- a/packages/commuter-server/src/server.js
+++ b/packages/commuter-server/src/server.js
@@ -1,24 +1,14 @@
 const express = require("express"),
   http = require("http"),
   path = require("path"),
-  bodyParser = require("body-parser"),
   morgan = require("morgan"),
   config = require("./config"),
   Log = require("log"),
   log = new Log("info");
 
-function defaultContentTypeMiddleware(req, res, next) {
-  req.headers["content-type"] = req.headers["content-type"] ||
-    "application/json";
-  next();
-}
-
 function createServer() {
   const app = express();
   app.use(morgan("common"));
-  app.use(defaultContentTypeMiddleware);
-  app.use(bodyParser.json({ limit: "50mb" })); //50mb is the current threshold
-  app.use(bodyParser.urlencoded({ extended: true }));
 
   app.use(express.static("static"));
 


### PR DESCRIPTION
This switches up how we set the default content type to only do it on `/api/` while also making our directories organized around the routes.