### PR TITLE
More renderers: JSON, Zeppelin

### DIFF
--- a/packages/commuter-client/src/Contents.js
+++ b/packages/commuter-client/src/Contents.js
@@ -5,6 +5,8 @@ import NotebookPreview from "@nteract/notebook-preview";
 import DirectoryListing from "@nteract/commuter-directory-listing";
 import BreadCrumb from "@nteract/commuter-breadcrumb";
 
+import JSONTransform from "@nteract/transforms/lib/json";
+
 import "normalize.css/normalize.css";
 import "codemirror/lib/codemirror.css";
 import "@nteract/notebook-preview/styles/main.css";
@@ -20,6 +22,8 @@ import { css } from "aphrodite";
 
 import { styles } from "./stylesheets/commuter";
 import stripView from "./strip-view";
+
+import ZeppelinView from "./zeppelin";
 
 class HTMLView extends React.Component {
   shouldComponentUpdate() {
@@ -50,17 +54,6 @@ class HTMLView extends React.Component {
   }
 }
 
-const ZeppelinView = props => {
-  return (
-    <div>
-      <h1>{props.notebook.name}</h1>
-      {props.notebook.paragraphs.map(paragraph => (
-        <pre key={paragraph.id}>{paragraph.text}</pre>
-      ))}
-    </div>
-  );
-};
-
 class File extends React.Component {
   shouldComponentUpdate() {
     return false;
@@ -73,23 +66,23 @@ class File extends React.Component {
 
     // Super mega advanced file detection
     if (this.props.entry.name.endsWith(".json")) {
-      // Zeppelin notebooks are called note.json, we'll go ahead and render them
-      if (this.props.entry.name === "note.json") {
-        try {
-          const notebook = JSON.parse(this.props.entry.content);
-          return <ZeppelinView notebook={notebook} />;
-        } catch (e) {
-          return (
-            <div>
-              <h1>Failed to parse Zeppelin Notebook</h1>
-              <pre>{e.toString()}</pre>
-              <code>{this.props.entry.content}</code>
-            </div>
-          );
+      const content = JSON.parse(this.props.entry.content);
+      try {
+        // Zeppelin notebooks are called note.json, we'll go ahead and render them
+        if (this.props.entry.name === "note.json") {
+          return <ZeppelinView notebook={content} />;
         }
-      }
 
-      return <pre>{this.props.entry.content}</pre>;
+        return <JSONTransform data={content} />;
+      } catch (e) {
+        return (
+          <div>
+            <h1>Failed to parse Zeppelin Notebook</h1>
+            <pre>{e.toString()}</pre>
+            <code>{this.props.entry.content}</code>
+          </div>
+        );
+      }
     }
 
     return <Redirect to={`/files${this.props.pathname}`} />;

--- a/packages/commuter-client/src/zeppelin.js
+++ b/packages/commuter-client/src/zeppelin.js
@@ -1,0 +1,135 @@
+import React from "react";
+
+import JSONTransform from "@nteract/transforms/lib/json";
+import HTML from "@nteract/transforms/lib/html";
+import Text from "@nteract/transforms/lib/text";
+
+import Editor from "@nteract/notebook-preview/lib/editor";
+
+const HokeyTable = props => (
+  <div>
+    <style>
+      {
+        `
+      table {
+        border-collapse: collapse;
+        border-spacing: 0;
+        border-collapse: collapse;
+        border-spacing: 0;
+        empty-cells: show;
+        border: 1px solid #cbcbcb;
+        max-height: 200px;
+        overflow-y: scroll;
+      }
+
+      td,
+      th {
+        padding: 0;
+        border-left: 1px solid #cbcbcb;/*  inner column border */
+      border-width: 0 0 0 1px;
+      font-size: inherit;
+      margin: 0;
+      overflow: visible; /*to make ths where the title is really long work*/
+      padding: 0.5em 1em; /* cell padding */
+      }
+
+      td:first-child,
+      th:first-child {
+          border-left-width: 0;
+      }
+
+      thead {
+          background-color: #e0e0e0;
+          color: #000;
+          text-align: left;
+          vertical-align: bottom;
+      }
+      `
+      }
+    </style>
+    <table>
+      <thead>
+        <tr>
+          {props.columnNames.map(column => (
+            <th key={column.index}>{column.name}</th>
+          ))}
+        </tr>
+      </thead>
+      <tbody>
+        {props.rows.map((row, idx) => (
+          <tr key={idx}>
+            {row.map((item, colIdx) => <td key={colIdx}>{item}</td>)}
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  </div>
+);
+
+const UnsupportedResult = props => (
+  <div>
+    <h1>UNSUPPORTED ZEPPELIN RESULT</h1>
+    <JSONTransform data={props.result} />
+  </div>
+);
+
+const Result = props => {
+  if (!props.result) {
+    return null;
+  }
+  switch (props.result.type) {
+    case "HTML":
+      return <HTML data={props.result.msg} />;
+    case "TEXT":
+      return <Text data={props.result.msg} />;
+    case "TABLE":
+      if (!props.result.columnNames || !props.result.rows) {
+        return <UnsupportedResult result={props.result} />;
+      }
+      return (
+        <HokeyTable
+          columnNames={props.result.columnNames}
+          rows={props.result.rows}
+        />
+      );
+  }
+  return <UnsupportedResult result={props.result} />;
+};
+
+const Paragraph = props => {
+  return (
+    <div>
+      <Editor
+        completion
+        input={props.text}
+        language="scala"
+        theme="composition"
+        cellFocused={false}
+        onChange={() => {}}
+        onFocusChange={() => {}}
+        channels={{}}
+        cursorBlinkRate={0}
+        executionState={"not connected"}
+        editorFocused={false}
+        focusAbove={() => {}}
+        focusBelow={() => {}}
+        style={{
+          paddingBottom: "10px",
+          paddingTop: "10px"
+        }}
+      />
+      <Result result={props.result} />
+    </div>
+  );
+};
+
+const ZeppelinView = props => {
+  return (
+    <div>
+      <h1>{props.notebook.name}</h1>
+      {props.notebook.paragraphs.map(p => <Paragraph key={p.id} {...p} />)}
+    </div>
+  );
+};
+
+export default ZeppelinView;

--- a/packages/commuter-client/src/zeppelin.js
+++ b/packages/commuter-client/src/zeppelin.js
@@ -69,6 +69,15 @@ const HokeyTable = props => (
 const UnsupportedResult = props => (
   <div>
     <h1>UNSUPPORTED ZEPPELIN RESULT</h1>
+    <p>
+      Post an issue to
+      {" "}
+      <a href="https://github.com/nteract/commuter/issues/new" target="_blank">
+        commuter
+      </a>
+      {" "}
+      to let us know about it
+    </p>
     <JSONTransform data={props.result} />
   </div>
 );
@@ -92,8 +101,9 @@ const Result = props => {
           rows={props.result.rows}
         />
       );
+    default:
+      return <UnsupportedResult result={props.result} />;
   }
-  return <UnsupportedResult result={props.result} />;
 };
 
 const Paragraph = props => {


### PR DESCRIPTION
Took the nteract components and a bit of table tomfoolery with (one of) their table attributes to create a rendition of the zeppelin notebook format:

![screen shot 2017-03-24 at 6 43 03 pm](https://cloud.githubusercontent.com/assets/836375/24318451/c2fa211a-10c2-11e7-8de7-dc623c7c7492.png)

![screen shot 2017-03-24 at 6 42 51 pm](https://cloud.githubusercontent.com/assets/836375/24318390/c633b248-10c1-11e7-8a7a-41999a4400ad.png)

In the future, I'd like to convert their table format over to the data resource so that we can use the transform from https://github.com/nteract/nteract/pull/1534 and get our fully interactive grid. :smile:

---------------------------

An aside on the tables, they encode it three different ways -- I assume to handle different versions of zeppelin over time...

![screen shot 2017-03-24 at 6 46 53 pm](https://cloud.githubusercontent.com/assets/836375/24318430/5c9298e4-10c2-11e7-9f72-a63027689d77.png)