### PR TITLE
Allow JSON and Markdown through the view route

### DIFF
--- a/packages/commuter-server/src/routes/view.js
+++ b/packages/commuter-server/src/routes/view.js
@@ -13,6 +13,9 @@ router.get("*", (req, res) => {
   if (
     req.path.endsWith(".ipynb") ||
     req.path.endsWith(".html") ||
+    req.path.endsWith(".json") ||
+    req.path.endsWith(".md") ||
+    req.path.endsWith(".Rmd") ||
     req.path.endsWith("/")
   ) {
     res.sendFile(path.resolve(__dirname, "..", "..", "build", "index.html"));


### PR DESCRIPTION
Allows JSON and Markdown to be viewed at `/view/`, unknown files still get served on `/files/`.