### PR TITLE
set the prefix via config.basePath

### DIFF
--- a/packages/commuter-server/src/routes/files.js
+++ b/packages/commuter-server/src/routes/files.js
@@ -7,7 +7,7 @@ router.get(
   "/*",
   s3Proxy({
     bucket: config.s3.params.Bucket,
-    /* prefix: s3pathPrefix */
+    prefix: config.basePath,
     accessKeyId: config.s3.accessKeyId,
     secretAccessKey: config.s3.secretAccessKey,
     overrideCacheControl: "max-age=100000"


### PR DESCRIPTION
This fixes `/files/` proxying