### PR TITLE
chore(hiddenFiles): trim hidden files in the reducer instead of directory listing component

### DIFF
--- a/packages/commuter-client/src/reducers/index.js
+++ b/packages/commuter-client/src/reducers/index.js
@@ -7,10 +7,16 @@ const commuter = (state = {}, action) => {
       return Object.assign({}, state, { isFetching: action.isFetching });
     case types.RECEIVE_CONTENTS:
     // filter out hidden files
-    const content = action.entry.type === 'directory' ?
-    action.entry.content.filter((file) => {
-      return !file.name.startsWith('.')
-    }) : action.entry.content;
+      let content;
+      switch (action.entry.type) {
+        case 'directory':
+          content = action.entry.content.filter((file) => {
+            return !file.name.startsWith('.');
+          });
+        break;
+      default:
+        return action.entry.content;
+      }
     const entry = Object.assign({}, action.entry, { content });
       return Object.assign({}, state, {
         entry,

--- a/packages/commuter-client/src/reducers/index.js
+++ b/packages/commuter-client/src/reducers/index.js
@@ -6,6 +6,10 @@ const commuter = (state = {}, action) => {
     case types.REQUEST_CONTENTS:
       return Object.assign({}, state, { isFetching: action.isFetching });
     case types.RECEIVE_CONTENTS:
+    // filter out hidden files
+    action.entry.content = action.entry.content.filter((file) => {
+      return !file.name.startsWith('.')
+    });
       return Object.assign({}, state, {
         entry: action.entry,
         isFetching: action.isFetching

--- a/packages/commuter-client/src/reducers/index.js
+++ b/packages/commuter-client/src/reducers/index.js
@@ -7,11 +7,13 @@ const commuter = (state = {}, action) => {
       return Object.assign({}, state, { isFetching: action.isFetching });
     case types.RECEIVE_CONTENTS:
     // filter out hidden files
-    action.entry.content = action.entry.content.filter((file) => {
+    const content = action.entry.type === 'directory' ?
+    action.entry.content.filter((file) => {
       return !file.name.startsWith('.')
-    });
+    }) : action.entry.content;
+    const entry = Object.assign({}, action.entry, { content });
       return Object.assign({}, state, {
-        entry: action.entry,
+        entry,
         isFetching: action.isFetching
       });
     default:

--- a/packages/commuter-directory-listing/src/DirectoryListing.js
+++ b/packages/commuter-directory-listing/src/DirectoryListing.js
@@ -20,9 +20,7 @@ const DirectoryListing = props => {
             <Table.Row />
           </Table.Header>
           <Table.Body>
-            {props.contents.filter((z) => {
-               return !z.name[0].startsWith('.');
-            }).map((row, index) => {
+            {props.contents.map((row, index) => {
               const fullPath = `${base}${row.path}`;
 
               switch (row.type) {


### PR DESCRIPTION
As suggested in #144, moving where the hidden files are trimmed to the reducer.