### PR TITLE
When Zepp markdown cell, only show result

### DIFF
--- a/packages/commuter-client/src/contents/zeppelin.js
+++ b/packages/commuter-client/src/contents/zeppelin.js
@@ -150,6 +150,19 @@ const whichLanguage = source => {
 
 const Paragraph = props => {
   const lang = whichLanguage(props.text);
+  if (lang === "markdown") {
+    return (
+      <div
+        style={{
+          paddingBottom: "10px",
+          paddingTop: "10px"
+        }}
+      >
+        <Result result={props.result} />
+      </div>
+    );
+  }
+
   return (
     <div>
       <Editor


### PR DESCRIPTION
Only show the rendered markdown when on a markdown cell for Zeppelin. Makes for a nice clean report-like view.