### PR TITLE
Restore proper links

### DIFF
--- a/packages/commuter-breadcrumb/__tests__/BreadCrumb.test.js
+++ b/packages/commuter-breadcrumb/__tests__/BreadCrumb.test.js
@@ -1,26 +1,28 @@
-import React from 'react';
-import renderer from 'react-test-renderer';
+import React from "react";
+import renderer from "react-test-renderer";
 
-import BreadCrumb from '../src';
+import BreadCrumb from "../src";
 
-it('renders correctly', () => {
-  const tree = renderer.create(
-    <BreadCrumb
-      path={"path/for/tests"}
-      onClick={() => {}}
-      basepath={"/view"}
-    />
-  ).toJSON();
-  expect(tree).toMatchSnapshot(); 
+import { MemoryRouter } from "react-router-dom";
+
+it("renders correctly", () => {
+  const tree = renderer
+    .create(
+      <MemoryRouter>
+        <BreadCrumb path={"path/for/tests"} basepath={"/view"} />
+      </MemoryRouter>
+    )
+    .toJSON();
+  expect(tree).toMatchSnapshot();
 });
 
-it('renders the correct number of elements', () => {
-  const tree = renderer.create(
-    <BreadCrumb
-      path={"path/for/tests"}
-      onClick={() => {}}
-      basepath={"/view"}
-    />
-  ).toJSON();
+it("renders the correct number of elements", () => {
+  const tree = renderer
+    .create(
+      <MemoryRouter>
+        <BreadCrumb path={"path/for/tests"} basepath={"/view"} />
+      </MemoryRouter>
+    )
+    .toJSON();
   expect(tree.children.length).toEqual(7);
 });

--- a/packages/commuter-breadcrumb/package.json
+++ b/packages/commuter-breadcrumb/package.json
@@ -26,6 +26,7 @@
     "lodash": "^4.17.4",
     "react": "^15.5.4",
     "react-dom": "^15.5.4",
+    "react-router-dom": "^4.1.1",
     "semantic-ui-react": "^0.67.2"
   },
   "devDependencies": {

--- a/packages/commuter-breadcrumb/src/BreadCrumb.js
+++ b/packages/commuter-breadcrumb/src/BreadCrumb.js
@@ -2,28 +2,21 @@ import React, { PropTypes as T } from "react";
 import { Breadcrumb } from "semantic-ui-react";
 import { trim } from "lodash";
 
+import { Link } from "react-router-dom";
+
 const BreadCrumb = props => {
   const { path, basepath, onClick } = props;
   const paths = trim(path, "/").split("/");
   let breadCrumbs = [];
 
-  const handleClick = path =>
-    e => {
-      if (onClick) {
-        e.preventDefault();
-        onClick(path);
-      }
-    };
-
   breadCrumbs.push(
     <Breadcrumb.Section key="home">
-      <a
-        href={`${basepath}/`}
-        onClick={handleClick(`${basepath}/`)}
+      <Link
+        to={`${basepath}/`}
         style={{ display: "block", width: "2em", height: "2em" }}
       >
         /
-      </a>
+      </Link>
     </Breadcrumb.Section>
   );
   paths.forEach((name, index) => {
@@ -41,12 +34,9 @@ const BreadCrumb = props => {
     else
       breadCrumbs.push(
         <Breadcrumb.Section key={`section-${index}`}>
-          <a
-            href={`${basepath}/${filePath}/`}
-            onClick={handleClick(`${basepath}/${filePath}/`)}
-          >
+          <Link to={`${basepath}/${filePath}/`}>
             {name}
-          </a>
+          </Link>
         </Breadcrumb.Section>
       );
   });

--- a/packages/commuter-client/src/contents/index.js
+++ b/packages/commuter-client/src/contents/index.js
@@ -112,7 +112,6 @@ const Entry = props => {
             className={css(styles.listing)}
             path={props.pathname}
             contents={props.entry.content}
-            onClick={props.handleClick}
             basepath={"/view"}
           />
         </Container>
@@ -149,7 +148,6 @@ class Contents extends React.Component {
   loadData = ({ location, dispatch }) => {
     dispatch(fetchContents(stripView(location.pathname)));
   };
-  handleClick = path => this.props.history.push(path);
 
   render() {
     const pathname = stripView(this.props.location.pathname);
@@ -161,17 +159,9 @@ class Contents extends React.Component {
             marginLeft: "2rem"
           }}
         >
-          <BreadCrumb
-            path={pathname}
-            onClick={this.handleClick}
-            basepath={"/view"}
-          />
+          <BreadCrumb path={pathname} basepath={"/view"} />
         </div>
-        <Entry
-          entry={this.props.entry}
-          pathname={pathname}
-          handleClick={this.handleClick}
-        />
+        <Entry entry={this.props.entry} pathname={pathname} />
       </Container>
     );
   }

--- a/packages/commuter-directory-listing/src/DirectoryListing.js
+++ b/packages/commuter-directory-listing/src/DirectoryListing.js
@@ -4,12 +4,6 @@ import { Table, Grid, Segment, Icon } from "semantic-ui-react";
 import { Link } from "react-router-dom";
 
 const DirectoryListing = props => {
-  const handleClick = path => e => {
-    if (props.onClick) {
-      e.preventDefault();
-      props.onClick(path);
-    }
-  };
   const base = props.basepath;
   return (
     <Grid>
@@ -29,9 +23,9 @@ const DirectoryListing = props => {
                   return (
                     <Table.Row key={index}>
                       <Table.Cell>
-                        <a href={fullPath} onClick={handleClick(fullPath)}>
+                        <Link to={fullPath}>
                           <Icon name="book" color="grey" />{row.name}
-                        </a>
+                        </Link>
                       </Table.Cell>
                       <Table.Cell collapsing textAlign="right" />
                     </Table.Row>
@@ -40,9 +34,9 @@ const DirectoryListing = props => {
                   return (
                     <Table.Row key={index}>
                       <Table.Cell collapsing>
-                        <a href={fullPath} onClick={handleClick(fullPath)}>
+                        <Link to={fullPath}>
                           <Icon name="folder" color="blue" />{row.name}
-                        </a>
+                        </Link>
                       </Table.Cell>
                       <Table.Cell collapsing textAlign="right" />
                     </Table.Row>
@@ -51,9 +45,9 @@ const DirectoryListing = props => {
                   return (
                     <Table.Row key={index}>
                       <Table.Cell collapsing>
-                        <a href={fullPath} onClick={handleClick(fullPath)}>
+                        <Link to={fullPath}>
                           <Icon name="file" color="grey" />{row.name}
-                        </a>
+                        </Link>
                       </Table.Cell>
                       <Table.Cell collapsing textAlign="right" />
                     </Table.Row>


### PR DESCRIPTION
The `onClick` handling that was in here didn't handle all the normal browser cases like being able to command-click to open links in new tabs. Since I'd rather not make this more complicated, I'd rather just rely on `<Link>`. This simplifies our setup to assume we rely on `react-router-dom`.