### PR TITLE
Base URI (base path)

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ COMMUTER_BUCKET=sweet-notebooks commuter server
 | `COMMUTER_PORT` | Port to run commuter on | 4000 |
 | `COMMUTER_LOCAL_STORAGE_BASEDIRECTORY` | directory to serve in local storage mode | `process.cwd()` |
 | `COMMUTER_ES_HOST` | ElasticSearch Host | `""` |
-| `process.env.COMMUTER_BASE_URI` | Base Path to serve commuter on | `/` |
+| `COMMUTER_BASE_URI` | Base Path to serve commuter on | `/` |
 
 ### Environment Variables for S3 Storage
 

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ COMMUTER_BUCKET=sweet-notebooks commuter server
 | `COMMUTER_PORT` | Port to run commuter on | 4000 |
 | `COMMUTER_LOCAL_STORAGE_BASEDIRECTORY` | directory to serve in local storage mode | `process.cwd()` |
 | `COMMUTER_ES_HOST` | ElasticSearch Host | `""` |
+| `process.env.COMMUTER_BASE_URI` | Base Path to serve commuter on | `/` |
 
 ### Environment Variables for S3 Storage
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "npm run build:components && npm run build:client",
     "build:client": "lerna exec --scope @nteract/commuter-client -- npm run build",
     "build:components": "lerna exec --ignore @nteract/commuter-client -- npm run build",
+    "build:server": "lerna exec --scope @nteract/commuter-server -- npm run build",
     "client": "lerna exec --scope @nteract/commuter-cli -- npm run client",
     "clean": "npm run clean:install && npm run clean:lib && npm run clean:build",
     "clean:install": "lerna clean",

--- a/packages/commuter-client/package.json
+++ b/packages/commuter-client/package.json
@@ -45,5 +45,6 @@
     "rx-jupyter": "^2.0.0",
     "semantic-ui-react": "^0.68.3"
   },
+  "homepage": "%COMMUTER_BASE_URI%/nteract/commuter",
   "proxy": "http://localhost:4000"
 }

--- a/packages/commuter-client/public/index.html
+++ b/packages/commuter-client/public/index.html
@@ -3,6 +3,7 @@
   <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
+    <script>window.baseURI = "%COMMUTER_BASE_URI%";</script>
     <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.2/semantic.min.css"></link>
     <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700,300,200,500,600,900' rel='stylesheet' type='text/css'>
@@ -23,7 +24,7 @@
     }
     </style>
   </head>
-  <body>
+  <body baseURL="/">
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/packages/commuter-client/public/index.html
+++ b/packages/commuter-client/public/index.html
@@ -4,7 +4,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <script>window.baseURI = "%COMMUTER_BASE_URI%";</script>
-    <link rel="shortcut icon" href="%PUBLIC_URL%/favicon.ico">
+    <link rel="shortcut icon" href="%COMMUTER_BASE_URI%/%PUBLIC_URL%/favicon.ico">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.2.2/semantic.min.css"></link>
     <link href='https://fonts.googleapis.com/css?family=Source+Code+Pro:400,700,300,200,500,600,900' rel='stylesheet' type='text/css'>
     <link href='https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,200,200italic,300,300italic,400italic,600,600italic,700,700italic,900,900italic' rel='stylesheet' type='text/css'>
@@ -24,7 +24,7 @@
     }
     </style>
   </head>
-  <body baseURL="/">
+  <body>
     <div id="root"></div>
     <!--
       This HTML file is a template.

--- a/packages/commuter-server/package.json
+++ b/packages/commuter-server/package.json
@@ -33,7 +33,6 @@
     "aws-sdk": "^2.41.0",
     "body-parser": "^1.15.2",
     "bodybuilder": "^2.0.0",
-    "cheerio": "^1.0.0-rc.1",
     "elasticsearch": "^12.1.3",
     "express": "^4.14.0",
     "jsonfile": "^2.4.0",

--- a/packages/commuter-server/package.json
+++ b/packages/commuter-server/package.json
@@ -33,6 +33,7 @@
     "aws-sdk": "^2.41.0",
     "body-parser": "^1.15.2",
     "bodybuilder": "^2.0.0",
+    "cheerio": "^1.0.0-rc.1",
     "elasticsearch": "^12.1.3",
     "express": "^4.14.0",
     "jsonfile": "^2.4.0",

--- a/packages/commuter-server/src/config.js
+++ b/packages/commuter-server/src/config.js
@@ -98,7 +98,7 @@ function instantiate() {
       config.discoveryBackend = "none";
   }
 
-  config.baseURI = process.env.COMMUTER_BASE_URI || "/";
+  config.baseURI = (process.env.COMMUTER_BASE_URI || "").replace(/\/+$/, "");
 
   config.nodeEnv = process.env.NODE_ENV || "test";
   config.port = process.env.PORT || process.env.COMMUTER_PORT || 4000;

--- a/packages/commuter-server/src/config.js
+++ b/packages/commuter-server/src/config.js
@@ -98,6 +98,8 @@ function instantiate() {
       config.discoveryBackend = "none";
   }
 
+  config.baseURI = process.env.COMMUTER_BASE_URI || "/";
+
   config.nodeEnv = process.env.NODE_ENV || "test";
   config.port = process.env.PORT || process.env.COMMUTER_PORT || 4000;
 

--- a/packages/commuter-server/src/routes/index.js
+++ b/packages/commuter-server/src/routes/index.js
@@ -36,6 +36,8 @@ function createRouter(config): express.Router {
     discovery: discoveryProvider.createDiscoveryRouter(config.discovery)
   });
 
+  console.log(config);
+
   const router = express.Router();
   router.use(
     "/nteract/commuter",

--- a/packages/commuter-server/src/routes/index.js
+++ b/packages/commuter-server/src/routes/index.js
@@ -63,6 +63,8 @@ function createRouter(config): express.Router {
     .toString()
     .replace(/%COMMUTER_BASE_URI%/g, config.baseURI);
 
+  console.log(basePage);
+
   router.get("*", (req: $Request, res: $Response) => {
     res.send(basePage);
   });

--- a/packages/commuter-server/src/routes/index.js
+++ b/packages/commuter-server/src/routes/index.js
@@ -2,13 +2,12 @@
 
 import type { $Request, $Response } from "express";
 
-const express = require("express"), path = require("path");
+const express = require("express"),
+  path = require("path");
 
 const fs = require("fs");
 
 const createAPIRouter = require("./api");
-
-const cheerio = require("cheerio");
 
 function createRouter(config): express.Router {
   let contentsProvider;

--- a/packages/commuter-server/src/routes/index.js
+++ b/packages/commuter-server/src/routes/index.js
@@ -44,7 +44,11 @@ function createRouter(config): express.Router {
   router.get("*", (req: $Request, res: $Response) => {
     res.sendFile(path.resolve(__dirname, "..", "..", "build", "index.html"));
   });
-  return router;
+
+  const baseRouter = express.Router();
+  baseRouter.use(config.baseURI, router);
+
+  return baseRouter;
 }
 
 // Keeping the singleton on the export to make it work in-place right now

--- a/packages/commuter-server/src/server.js
+++ b/packages/commuter-server/src/server.js
@@ -12,14 +12,10 @@ function createServer() {
   const app = express();
   app.use(morgan("common"));
 
+  // Route config prefix needs to go here too...
   app.use(express.static("static"));
 
   log.info(`Node env: ${config.nodeEnv}`);
-
-  app.use(
-    "/nteract/commuter",
-    express.static(path.resolve(__dirname, "..", "build"))
-  );
 
   // Last middleware
   app.use(require("./routes"));

--- a/packages/commuter-server/src/server.js
+++ b/packages/commuter-server/src/server.js
@@ -17,6 +17,11 @@ function createServer() {
 
   log.info(`Node env: ${config.nodeEnv}`);
 
+  app.use(
+    "/nteract/commuter",
+    express.static(path.resolve(__dirname, "..", "build"))
+  );
+
   // Last middleware
   app.use(require("./routes"));
 


### PR DESCRIPTION
Work in progress, not ready for merging.

* [x] Set base path using an environment variable
* [x] Configure the base path in the server
* [ ] Reconfigure frontend to work with the base path

Note that I called the environment variable `COMMUTER_BASE_URI` because we already have a `COMMUTER_BASE_PATH` that we deprecated from the S3 setup. I'd be happy to make this `COMMUTER_BASE_PATH` since it would match the jupyter naming convention.