### PR TITLE
let express do the static file serving from EFS

### DIFF
--- a/packages/commuter-server/src/content-providers/local/files.js
+++ b/packages/commuter-server/src/content-providers/local/files.js
@@ -18,36 +18,7 @@ function createRouter(options: DiskProviderOptions) {
     throw new Error("Base directory must be specified for the local provider");
   }
 
-  const router = express.Router();
-
-  router.get("/*", (req: $Request, res: $Response) => {
-    const unsafeFilePath = req.params["0"];
-
-    const filePath = path.join(
-      options.local.baseDirectory,
-      sanitizeFilePath(unsafeFilePath)
-    );
-
-    // Assume it's a file by default, fall to error handling otherwise
-    const rs = fs.createReadStream(filePath);
-
-    rs.on("error", err => {
-      const errorResponse: ErrorResponse = {
-        message: `${err.message}: ${filePath}`
-      };
-
-      if (err.code === "ENOENT" || err.code === "EACCES") {
-        res.status(404).send(errorResponse);
-        return;
-      }
-
-      console.error(err.stack);
-      res.status(500).send(errorResponse);
-    });
-
-    rs.pipe(res);
-  });
-  return router;
+  return express.static(options.local.baseDirectory);
 }
 
 module.exports = {


### PR DESCRIPTION
Less code and full handling of `index.html`. We'll probably want to make a custom content security policy for this path though.