### PR TITLE
Update demo URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Heroku](https://heroku-badge.herokuapp.com/?app=nteract-commuter&svg=1)](https://nteract-commuter.herokuapp.com/)
+[▲ Now](https://commuter-now-huyifhhoqx.now.sh/view/)
 [![Build Status](https://travis-ci.org/nteract/commuter.svg?branch=master)](https://travis-ci.org/nteract/commuter)
 [![Greenkeeper badge](https://badges.greenkeeper.io/nteract/commuter.svg)](https://greenkeeper.io/)
 [![styled with prettier](https://img.shields.io/badge/styled_with-prettier-ff69b4.svg)](https://github.com/prettier/prettier)
@@ -28,7 +28,7 @@ and convenience.
 
 Try **commuter** today and take your notebooks wherever you need them.
 
-[Demo](https://nteract-commuter.herokuapp.com/)
+[Demo](https://commuter-now-huyifhhoqx.now.sh/view/)
 
 ## Installation
 


### PR DESCRIPTION
https://commuter-now-huyifhhoqx.now.sh/view/

This is on the nteract now.sh account. Once I move the domain over there we can run commuter on `commuter.nteract.io` or something.