### PR TITLE
include mathjax on the commuter page

### DIFF
--- a/packages/frontend/.gitignore
+++ b/packages/frontend/.gitignore
@@ -2,3 +2,4 @@
 static/codemirror
 static/font-awesome
 static/notebook-preview
+static/mathjax-electron

--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -9,15 +9,22 @@
     "start": "echo \"This must be run with the commuter server\"",
     "test": "echo \"no test for now\"",
     "precopy-fontawesome": "mkdirp static/font-awesome/",
-    "copy-fontawesome": "cp node_modules/font-awesome/css/font-awesome.min.css static/font-awesome",
+    "copy-fontawesome":
+      "cp node_modules/font-awesome/css/font-awesome.min.css static/font-awesome",
     "precopy-nbp": "mkdirp static/notebook-preview/",
-    "copy-nbp": "cp node_modules/@nteract/notebook-preview/styles/* static/notebook-preview",
+    "copy-nbp":
+      "cp node_modules/@nteract/notebook-preview/styles/* static/notebook-preview",
+    "precopy-mathjax": "mkdirp static/mathjax-electron",
+    "copy-mathjax": "cp -r node_modules/mathjax-electron static",
     "precopy-codemirror": "mkdirp static/codemirror",
-    "copy-codemirror": "cp node_modules/codemirror/lib/codemirror.css static/codemirror/",
-    "copy-static": "npm run copy-nbp && npm run copy-codemirror && npm run copy-fontawesome",
+    "copy-codemirror":
+      "cp node_modules/codemirror/lib/codemirror.css static/codemirror/",
+    "copy-static":
+      "npm run copy-nbp && npm run copy-codemirror && npm run copy-fontawesome && npm run copy-mathjax",
     "prepare": "npm run copy-static",
     "prepublish": "npm run copy-static",
-    "comment": "echo 'we copy assets over to a non-version controlled folder in static for next to serve'",
+    "comment":
+      "echo 'we copy assets over to a non-version controlled folder in static for next to serve'",
     "prepublishOnly": "npm run build"
   },
   "publishConfig": {
@@ -39,6 +46,7 @@
     "@nteract/transform-vega": "^2.2.1",
     "@nteract/transforms": "^2.4.1",
     "babel-preset-flow": "^6.23.0",
+    "mathjax-electron": "^2.0.1",
     "d3-dsv": "^1.0.7",
     "font-awesome": "^4.7.0",
     "isomorphic-fetch": "^2.2.1",
@@ -52,20 +60,10 @@
     "react-timeago": "^3.4.3",
     "styled-jsx": "^1.0.10"
   },
-  "files": [
-    ".next",
-    "pages",
-    "static",
-    "components",
-    "index.js"
-  ],
+  "files": [".next", "pages", "static", "components", "index.js"],
   "babel": {
-    "presets": [
-      "next/babel"
-    ],
-    "plugins": [
-      "transform-flow-strip-types"
-    ]
+    "presets": ["next/babel"],
+    "plugins": ["transform-flow-strip-types"]
   },
   "devDependencies": {
     "flow-bin": "^0.54.1"

--- a/packages/frontend/pages/_document.js
+++ b/packages/frontend/pages/_document.js
@@ -91,6 +91,11 @@ class MyDocument extends Document {
           <link rel="stylesheet" type="text/css" href="/static/commuter.css" />
 
           <script src="https://cdn.plot.ly/plotly-latest.min.js" />
+
+          <script
+            type="text/javascript"
+            src="/static/mathjax-electron/resources/MathJax/MathJax.js?config=electron"
+          />
         </Head>
         <body>
           <Main />

--- a/packages/server/examples/table-with-schema.ipynb
+++ b/packages/server/examples/table-with-schema.ipynb
@@ -1264,6 +1264,43 @@
       }
     },
     {
+      "cell_type": "markdown",
+      "source": [
+        "Inline math should work $\\alpha = 3 $, even if flickery...\n",
+        "\n$$ Block_{math} \\approx cool $$"
+      ],
+      "metadata": {}
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from IPython.display import Markdown\n",
+        "\n",
+        "Markdown(\"\"\"\n",
+        "\n",
+        "$$x = 2$$\n",
+        "\"\"\")"
+      ],
+      "outputs": [
+        {
+          "output_type": "execute_result",
+          "execution_count": 1,
+          "data": {
+            "text/plain": [
+              "<IPython.core.display.Markdown object>"
+            ],
+            "text/markdown": [
+              "\n\n",
+              "$$x = 2$$\n"
+            ]
+          },
+          "metadata": {}
+        }
+      ],
+      "execution_count": 1,
+      "metadata": {}
+    },
+    {
       "cell_type": "code",
       "source": [],
       "outputs": [],
@@ -1286,7 +1323,7 @@
     },
     "language_info": {
       "name": "python",
-      "version": "3.6.0",
+      "version": "3.6.2",
       "mimetype": "text/x-python",
       "codemirror_mode": {
         "name": "ipython",
@@ -1295,6 +1332,9 @@
       "pygments_lexer": "ipython3",
       "nbconvert_exporter": "python",
       "file_extension": ".py"
+    },
+    "nteract": {
+      "version": "0.2.0"
     }
   },
   "nbformat": 4,


### PR DESCRIPTION
Globally included mathjax in the page, which I'm not stoked about. I do know our config requires an imperative call at least, which is controlled by the mathjax-electron module. Our name for our version of mathjax is a bit of a misnomer, I wonder if we should rename @lgeiger (it works well in Chrome at least).

One day I'd love a nice trim mathjax scoped to the notebook. ;)

Closes #174 