### PR TITLE
allow toggling discovery in the header

### DIFF
--- a/packages/frontend/components/header.js
+++ b/packages/frontend/components/header.js
@@ -17,11 +17,13 @@ import { theme } from "../theme";
 
 class CommuterMenu extends React.Component<*> {
   props: {
-    active: ActiveType
+    active: ActiveType,
+    discoveryEnabled: boolean
   };
 
   static defaultProps = {
-    active: "view"
+    active: "view",
+    discoveryEnabled: true
   };
 
   handleItemClick = (e: SyntheticEvent<*>, { name }: { name: string }) => {
@@ -45,11 +47,13 @@ class CommuterMenu extends React.Component<*> {
               <a>Browse</a>
             </Link>
           </li>
-          <li className={this.isActiveClass("discover")}>
-            <Link href={"/discover"}>
-              <a>Discover</a>
-            </Link>
-          </li>
+          {this.props.discoveryEnabled ? (
+            <li className={this.isActiveClass("discover")}>
+              <Link href={"/discover"}>
+                <a>Discover</a>
+              </Link>
+            </li>
+          ) : null}
         </ul>
         <style jsx>{`
           nav {

--- a/packages/frontend/pages/discover.js
+++ b/packages/frontend/pages/discover.js
@@ -115,10 +115,11 @@ const DiscoveryItem = props => (
 );
 
 class DiscoveryGrid extends React.Component<*> {
-  static async getInitialProps({ req, pathname, asPath, query }) {
+  static async getInitialProps({ req }) {
     let BASE_PATH;
 
     if (req) {
+      // Server side, communicate with our local API
       const port = process.env.COMMUTER_PORT || 4000;
       BASE_PATH = `http://127.0.0.1:${port}/`;
     } else {

--- a/packages/frontend/pages/index.js
+++ b/packages/frontend/pages/index.js
@@ -5,9 +5,11 @@ import Link from "next/link";
 class IndexPage extends React.Component<*> {
   static async getInitialProps(ctx) {
     if (ctx.res) {
+      // Server side, do a redirect using the HTTP response object
       ctx.res.writeHead(302, { Location: "/view/" });
       ctx.res.end();
     } else {
+      // Client side redirect
       document.location.pathname = "/view/";
     }
     return {};

--- a/packages/frontend/pages/view.js
+++ b/packages/frontend/pages/view.js
@@ -12,7 +12,7 @@ import Body from "../components/body";
 import { Entry } from "../components/contents";
 
 class ViewPage extends React.Component<*> {
-  static async getInitialProps({ req, pathname, asPath, query }) {
+  static async getInitialProps({ req, query }) {
     // Later, we'll use this to fill in the notebook
     // file data from the server side (or fallback to /api/contents)
     // For now, leaving "server": boolean to assist in debugging
@@ -25,6 +25,7 @@ class ViewPage extends React.Component<*> {
     let BASE_PATH;
 
     if (req) {
+      // Server side, communicate with our local API
       const port = process.env.COMMUTER_PORT || 4000;
       BASE_PATH = `http://127.0.0.1:${port}/`;
     } else {
@@ -46,6 +47,7 @@ class ViewPage extends React.Component<*> {
   }
 
   render() {
+    console.log(this.props.services);
     if (this.props.statusCode) {
       return <div>{`Nothing found for ${this.props.viewPath}`}</div>;
     }


### PR DESCRIPTION
/cc @parente 

This makes discovery a togglable navigation component for when `discoveryEnabled` is set. Note this _only_ affects the component here, and I haven't figured a decent approach to disabling discovery when it's not configured.