### PR TITLE
Add support for POSTing files to the local contents provider

### DIFF
--- a/flow-typed/npm/fs-extra_vx.x.x.js
+++ b/flow-typed/npm/fs-extra_vx.x.x.js
@@ -1,0 +1,3 @@
+declare module 'fs-extra' {
+  declare module.exports: any;
+}

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -41,6 +41,7 @@
     "bodybuilder": "^2.2.1",
     "elasticsearch": "^12.1.3",
     "express": "^4.15.4",
+    "fs-extra": "^4.0.2",
     "jsonfile": "^3.0.1",
     "lodash": "^4.17.4",
     "log": "^1.4.0",

--- a/packages/server/src/content-providers/local/contents.js
+++ b/packages/server/src/content-providers/local/contents.js
@@ -42,6 +42,18 @@ function createRouter(options: DiskProviderOptions) {
         res.status(500).json(errorResponse);
       });
   });
+  router.post("/*", (req: $Request, res: $Response) => {
+    const path = req.params["0"];
+    fs
+      .post(options, path, req.body)
+      .then(() => res.status(201).send())
+      .catch((err: ErrnoError) => {
+        const errorResponse: ErrorResponse = {
+          message: `${err.message}: ${path}`
+        };
+        res.status(500).json(errorResponse);
+      });
+  });
   return router;
 }
 module.exports = {

--- a/packages/server/src/content-providers/local/fs.js
+++ b/packages/server/src/content-providers/local/fs.js
@@ -4,7 +4,7 @@
  * Local storage provider for commuter
  */
 
-const fs = require("fs");
+const fs = require("fs-extra");
 const path = require("path");
 
 import type {
@@ -160,6 +160,18 @@ function get(
   });
 }
 
+function post(
+  options: DiskProviderOptions,
+  unsafeFilePath: string,
+  content: mixed
+) {
+  const filePath = path.join(
+    options.local.baseDirectory,
+    sanitizeFilePath(unsafeFilePath)
+  );
+  return fs.outputFile(filePath, JSON.stringify(content));
+}
+
 function getDirectory(
   options: DiskProviderOptions,
   directory: DirectoryContent
@@ -249,5 +261,6 @@ function getNotebook(
 
 module.exports = {
   get,
+  post,
   sanitizeFilePath
 };


### PR DESCRIPTION
For testing it was useful to be able to POST files to the local backend.

---

Semi related question: I think the jupyter notebook uses PUT when you hit "Save" to update the contents of the notebook. commuter seems to conform to the contents provider API except you POST files instead of PUTing. Is the resemblance to the contents API accidental or does it actually not matter or just not implemented?