### PR TITLE
Add a description of GCP credentials to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ COMMUTER_BUCKET=sweet-notebooks commuter
 | `COMMUTER_S3_SECRET`         | AWS Secret                                      | Optional, uses IAM roles or `~/.aws/credentials` otherwise |
 | `COMMUTER_S3_ENDPOINT`       | S3 endpoint                                     | Optional, selected automatically                           |
 
+### Environment Variables for S3 Storage
+
+| Environment Variable             | Description                                                       | Default |
+| ---------------------------------| :---------------------------------------------------------------- | :------ |
+| `GOOGLE_APPLICATION_CREDENTIALS` | file path of the JSON file that contains your service account key | `""`    |
+
 ## Roadmap
 
 [ROADMAP Document](./ROADMAP.md)

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ COMMUTER_BUCKET=sweet-notebooks commuter
 | `COMMUTER_S3_SECRET`         | AWS Secret                                      | Optional, uses IAM roles or `~/.aws/credentials` otherwise |
 | `COMMUTER_S3_ENDPOINT`       | S3 endpoint                                     | Optional, selected automatically                           |
 
-### Environment Variables for S3 Storage
+### Environment Variables for Google Storage
 
 | Environment Variable             | Description                                                       | Default |
 | ---------------------------------| :---------------------------------------------------------------- | :------ |


### PR DESCRIPTION
# What

* Add a description of GCP credentials to README
  * The 4th step in https://www.npmjs.com/package/@google-cloud/storage#before-you-begin is to configure this environment variable

# Why

* For GCS backend

