### PR TITLE
add an option to enable s3ForcePathStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ COMMUTER_BUCKET=sweet-notebooks commuter
 | `COMMUTER_S3_KEY`            | AWS Key                                         | Optional, uses IAM roles or `~/.aws/credentials` otherwise |
 | `COMMUTER_S3_SECRET`         | AWS Secret                                      | Optional, uses IAM roles or `~/.aws/credentials` otherwise |
 | `COMMUTER_S3_ENDPOINT`       | S3 endpoint                                     | Optional, selected automatically                           |
-| `COMMUTER_S3_FORCE_PATH_STYLE`| Set to `true` to activate `s3ForcePathStyle`     | `false`                                                      |
+| `COMMUTER_S3_FORCE_PATH_STYLE`| Set to `true` to activate `s3ForcePathStyle`. Forces path-style URLs for s3 objects, therefore URLs will be in the form `<endpoint>/<bucket>/<key>` instead of `<bucket>.<endpoint>/<key>`     | `false`                                                      |
 
 ### Environment Variables for Google Storage
 

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ COMMUTER_BUCKET=sweet-notebooks commuter
 | `COMMUTER_S3_KEY`            | AWS Key                                         | Optional, uses IAM roles or `~/.aws/credentials` otherwise |
 | `COMMUTER_S3_SECRET`         | AWS Secret                                      | Optional, uses IAM roles or `~/.aws/credentials` otherwise |
 | `COMMUTER_S3_ENDPOINT`       | S3 endpoint                                     | Optional, selected automatically                           |
+| `COMMUTER_S3_FORCE_PATH_STYLE`| Set to `true` to activate `s3ForcePathStyle`     | `false`                                                      |
 
 ### Environment Variables for Google Storage
 

--- a/backend/config.js
+++ b/backend/config.js
@@ -43,6 +43,10 @@ function populateS3Options(env): Object {
 
   const s3Endpoint =
     env.COMMUTER_S3_ENDPOINT || "";
+  
+  // only interpret "true" as true otherwise false
+  const s3ForcePathStyle = /^true$/i.test(
+    env.COMMUTER_S3_FORCE_PATH_STYLE || "");
 
   const config = {
     s3: {
@@ -54,7 +58,8 @@ function populateS3Options(env): Object {
       accessKeyId: env.COMMUTER_S3_KEY,
       // required secret
       secretAccessKey: env.COMMUTER_S3_SECRET,
-      endpoint: s3Endpoint
+      endpoint: s3Endpoint,
+      s3ForcePathStyle: s3ForcePathStyle
     },
     s3PathDelimiter,
     s3BasePrefix


### PR DESCRIPTION
Hi, 

I was trying to configure Commuter with the S3 compatible object storage [MinIO](https://min.io/) however I would get the following error:
```
[Error [AjaxError]: ajax error 500] {
  xhr: {
    UNSENT: 0,
    OPENED: 1,
    HEADERS_RECEIVED: 2,
    LOADING: 3,
    DONE: 4,
    readyState: 4,
    onreadystatechange: [Function: xhrReadyStateChange] {
      subscriber: [AjaxSubscriber],
      progressSubscriber: undefined,
      request: [Object]
    },
    responseText: '{"message":"getaddrinfo ENOTFOUND <MY_BUCKET_NAME_REDACTED>.<MY_ENDPOINT_REDACTED>: ","reason":"NetworkingError"}',
    responseXML: '',
    status: 500,
    statusText: null,
    withCredentials: false,
    open: [Function (anonymous)],
    setDisableHeaderCheck: [Function (anonymous)],
    setRequestHeader: [Function (anonymous)],
    getResponseHeader: [Function (anonymous)],
    getAllResponseHeaders: [Function (anonymous)],
    getRequestHeader: [Function (anonymous)],
    send: [Function (anonymous)],
    handleError: [Function (anonymous)],
    abort: [Function (anonymous)],
    addEventListener: [Function (anonymous)],
    removeEventListener: [Function (anonymous)],
    dispatchEvent: [Function (anonymous)],
    ontimeout: [Function: xhrTimeout] {
      request: [Object],
      subscriber: [AjaxSubscriber],
      progressSubscriber: undefined
    },
    onload: [Function: xhrLoad] {
      subscriber: [AjaxSubscriber],
      progressSubscriber: undefined,
      request: [Object]
    },
    timeout: 0,
    responseType: 'json'
  },
  request: {
    async: true,
    createXHR: [Function: createXHR],
    crossDomain: true,
    withCredentials: false,
    headers: {},
    method: 'GET',
    responseType: 'json',
    timeout: 0,
    url: 'http://127.0.0.1:4000/api/contents//',
    body: undefined
  },
  status: 500,
  responseType: 'json',
  response: {
    message: 'getaddrinfo ENOTFOUND <MY_BUCKET_NAME_REDACTED>.<MY_ENDPOINT_REDACTED>: ',
    reason: 'NetworkingError'
  }
}
```

This is using version `5.9.1`.
I noticed from the MinIO's guide to use `aws-sdk` that the configuration should be something like this ([source](https://docs.min.io/docs/how-to-use-aws-sdk-for-javascript-with-minio-server.html)):
```javascript
var s3  = new AWS.S3({
          accessKeyId: 'YOUR-ACCESSKEYID' ,
          secretAccessKey: 'YOUR-SECRETACCESSKEY' ,
          endpoint: 'http://127.0.0.1:9000' ,
          s3ForcePathStyle: true, // needed with minio
          signatureVersion: 'v4'
});
```
So what I did was adding the `s3ForcePathStyle: true` and it works nicely with MinIO.
How about we add an environmental variable called COMMUTER_S3_FORCE_PATH_STYLE or something like that so by setting it commuter can be used with MinIO and I suspect other tools or use-cases this option is needed?
I went ahead and created a PR. Any thoughts? 

p.s. I'm not quite familiar with javascript coding conventions