### PR TITLE
Add Dockerfile

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+.next
+flow-typed
+lib
+node_modules

--- a/Dockerfile
+++ b/Dockerfile
@@ -74,9 +74,5 @@ COPY --from=build /opt/build/lib /opt/app/lib
 COPY --from=build /opt/build/public /opt/app/public
 COPY --from=dependencies /opt/build/node_modules /opt/app/node_modules
 
-ENV PORT=4000
-
-EXPOSE 4000
-
 ENTRYPOINT ["/tini", "-g", "--"]
 CMD [ "node", "lib/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,6 +57,11 @@ RUN yarn install --production=true
 ##################################
 FROM node:14-slim as release
 
+# Install tini
+ARG TINI_VERSION=v0.19.0
+ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
+RUN chmod +x /tini
+
 ENV NODE_ENV='production'
 
 RUN mkdir -p /opt/app;
@@ -73,4 +78,5 @@ ENV PORT=4000
 
 EXPOSE 4000
 
+ENTRYPOINT ["/tini", "-g", "--"]
 CMD [ "node", "lib/index.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,76 @@
+##################################
+# Build
+##################################
+FROM node:14 as build
+
+RUN mkdir -p /opt/build;
+
+WORKDIR /opt/build
+
+# Would be a bit simpler if the code was inside a top-level src folder
+COPY ./backend ./backend
+COPY ./components ./components
+COPY ./pages ./pages
+COPY ./public ./public
+COPY ./shims ./shims
+COPY ./transforms ./transforms
+COPY [ \
+  "babel.config.js", \
+  "frontend.js", \
+  "next.config.js", \
+  "package.json", \
+  "theme.js", \
+  "yarn.lock", \
+  "./" \
+]
+
+RUN yarn install \
+  && yarn build
+
+##################################
+# Dependencies
+##################################
+FROM node:14 as dependencies
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update && \
+  apt-get install --yes --no-install-recommends \
+  build-essential \
+  libcairo2-dev \
+  libpango1.0-dev \
+  libjpeg-dev \
+  libgif-dev \
+  librsvg2-dev
+
+ENV NODE_ENV='production'
+
+RUN mkdir -p /opt/build;
+
+WORKDIR /opt/build
+
+COPY --from=build [ "/opt/build/package.json", "/opt/build/yarn.lock", "./" ]
+
+RUN yarn install --production=true
+
+##################################
+# Release
+##################################
+FROM node:14-slim as release
+
+ENV NODE_ENV='production'
+
+RUN mkdir -p /opt/app;
+
+WORKDIR /opt/app
+
+COPY --from=build /opt/build/.next /opt/app/.next
+COPY --from=build /opt/build/frontend.js /opt/app/
+COPY --from=build /opt/build/lib /opt/app/lib
+COPY --from=build /opt/build/public /opt/app/public
+COPY --from=dependencies /opt/build/node_modules /opt/app/node_modules
+
+ENV PORT=4000
+
+EXPOSE 4000
+
+CMD [ "node", "lib/index.js" ]

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,0 +1,25 @@
+##################################################
+# Local dev image only
+# See: Dockerfile and README for Production image
+##################################################
+
+FROM node:14
+
+RUN DEBIAN_FRONTEND=noninteractive \
+  apt-get update && \
+  apt-get install --yes --no-install-recommends \
+  build-essential \
+  libcairo2-dev \
+  libpango1.0-dev \
+  libjpeg-dev \
+  libgif-dev \
+  librsvg2-dev && \
+  \
+  rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+RUN yarn install
+
+ENV NODE_ENV='development'
+CMD [ "node", "lib/index.js" ]

--- a/README.md
+++ b/README.md
@@ -100,6 +100,23 @@ COMMUTER_BUCKET=sweet-notebooks commuter
 1. `yarn dev`
 1. open `http://localhost:4000`
 
+#### Dev Docker
+A Dockerfile for a local dev server can be use as follows:
+
+1. `docker build -t commuter:dev -f Dockerfile.dev .`
+1. Run this:
+<pre>
+docker run \
+    --init \
+    --interactive \
+    --tty \
+    --rm \
+    --publish 4000:4000 \
+    --mount type=bind,source=(pwd),target=/app \
+    --env COMMUTER_LOCAL_STORAGE_BASEDIRECTORY=/app/examples \
+    commuter:dev
+</pre>
+
 ## Tests
 
 There are three ways you can run tests:
@@ -112,3 +129,21 @@ There are three ways you can run tests:
 
 1. Install commuter cli `yarn add @nteract/commuter`
 1. `exec commuter` - the service is typically wrapped inside [daemontools](https://cr.yp.to/daemontools.html)
+
+## Deployment (Docker / Kubernetes)
+
+A `Dockerfile` intended for Production use (suitable for Kubernetes or other container runtime) has 
+been contributed. Instructions are below. 
+
+Note: there is no officially published Docker image at this time, you should publish it to your own
+image registry.
+
+1. Build and tag image `docker build --tag commuter:latest .`
+1. Image can be executed as follows:
+<pre>
+docker run \
+--publish 4000:4000 \
+--mount type=bind,source=/home/username/work/commuter/examples,target=/examples \
+--env COMMUTER_LOCAL_STORAGE_BASEDIRECTORY=/examples \
+commuter:latest
+</pre>

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ COMMUTER_BUCKET=sweet-notebooks commuter
 #### Dev Docker
 A Dockerfile for a local dev server can be use as follows:
 
-1. `docker build -t commuter:dev -f Dockerfile.dev .`
+1. `docker build --tag commuter:dev --file Dockerfile.dev .`
 1. Run this:
 <pre>
 docker run \


### PR DESCRIPTION
Adds a Dockerfile for running commuter in a production environment

There is an old PR still open for adding simple Docker support, but that appears more suitable for local development: https://github.com/nteract/commuter/issues/188

This PR is intended to build a Docker container suitable for publishing to Dockerhub (or other registry) and be run in a production environment such as Kubernetes.

It can be tested locally as follows:
```
checkout this branch

docker build --tag commuter:latest .

docker run \
--publish 4000:4000 \
--mount type=bind,source=/home/username/work/commuter/examples,target=/examples \
--env COMMUTER_LOCAL_STORAGE_BASEDIRECTORY=/examples \
commuter:latest
```

*or* (use my prebuilt image)

```
checkout commuter master branch

docker run \
--publish 4000:4000 \
--mount type=bind,source=/home/username/work/commuter/examples,target=/examples \
--env COMMUTER_LOCAL_STORAGE_BASEDIRECTORY=/examples \
groodt/commuter:latest
```